### PR TITLE
Complete the local and agent file ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,15 @@ copilot-instructions.md
 
 # local security scan tooling (contains credentials, never commit)
 scripts/scan.sh
+
+# --- local AI / scan workspace (do not commit) ---
+results/
+.sonarqube/
+*-secrets.json
+.env.*
+!.env.example
+
+# --- AI agent instruction files (do not commit) ---
+QWEN.md
+.clinerules
+.windsurfrules


### PR DESCRIPTION
Brings this repo's `.gitignore` up to the workspace baseline.

## What changed

Only the missing entries were added, so rules the repo already had are untouched.

```
# --- local AI / scan workspace (do not commit) ---
results/
.sonarqube/
*-secrets.json
.env.*
!.env.example
# --- AI agent instruction files (do not commit) ---
QWEN.md
.clinerules
.windsurfrules
```

Agent instruction files are ignored defensively, so an assistant dropping one into the
tree cannot commit it by accident. The rest keeps generated and machine-local output out
of the repo.

## Verification

- Nothing currently tracked is shadowed by the new rules (`git ls-files | git check-ignore --stdin` is empty).
- Re-running the same fix adds nothing, so the change is idempotent.
- Code graph refreshed with `graphify update` before pushing.
- gitleaks run over the repo. No secret is introduced by this change.
