### PR TITLE
feat: ask IAM for the signup url instead of building it

### DIFF
--- a/.changeset/light-moons-smile.md
+++ b/.changeset/light-moons-smile.md
@@ -1,0 +1,11 @@
+---
+"@seliseblocks/genesis-os": minor
+---
+
+Route the landing page Sign up button through `/api/idp/initiate?flow=signup` so IAM validates the client and redirect URI before returning the signup URL.
+
+The button previously linked to a URL built in the browser, carrying no `clientId` or `redirect_uri`. Those two ride all the way into the activation email, and without them IAM falls back to the tenant's first active OIDC client — so signing up from one project could send the activation link back to a different one. Asking IAM for the URL means the redirect URI in that email is one the backend confirmed is registered.
+
+Requires an IAM release that understands the `flow` parameter. Until then the package refuses to redirect and surfaces an error rather than silently landing people on the login page.
+
+Note for anyone consuming the hook directly: `useSignUpAffordance` no longer returns a `signUpUrl` string. There is no URL to hand out any more — the URL comes from IAM at click time — so it returns `{ canSignUp, isLoading }`, and the new `useSignUpRedirect` performs the navigation. `LoginPage` is wired up already and needs nothing from callers.

--- a/packages/compose-react/src/hooks/use-login.test.tsx
+++ b/packages/compose-react/src/hooks/use-login.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const h = vi.hoisted(() => ({ startLogin: vi.fn() }));
+const h = vi.hoisted(() => ({ startFlow: vi.fn() }));
 vi.mock("@/services/login.service", () => ({ loginService: h }));
 
 import { useLogin } from "./use-login";
@@ -22,7 +22,7 @@ const wrapper = () => {
 };
 
 beforeEach(() => {
-  h.startLogin.mockReset();
+  h.startFlow.mockReset();
   Object.defineProperty(window, "location", {
     configurable: true,
     value: { origin: "https://app.test", href: "" },
@@ -31,7 +31,7 @@ beforeEach(() => {
 
 describe("useLogin", () => {
   it("starts login and navigates to the redirect_uri on success", async () => {
-    h.startLogin.mockResolvedValue({ redirect_uri: "https://idp/authorize" });
+    h.startFlow.mockResolvedValue({ redirect_uri: "https://idp/authorize" });
 
     const { result } = renderHook(() => useLogin(), { wrapper: wrapper() });
 
@@ -42,14 +42,14 @@ describe("useLogin", () => {
     await waitFor(() =>
       expect(window.location.href).toBe("https://idp/authorize"),
     );
-    expect(h.startLogin.mock.calls[0]?.[0]).toEqual({
+    expect(h.startFlow.mock.calls[0]?.[0]).toEqual({
       redirectUri: "https://app.test/login/callback",
     });
     expect(result.current.isLoading).toBe(false);
   });
 
   it("does not navigate when no redirect_uri is returned", async () => {
-    h.startLogin.mockResolvedValue({});
+    h.startFlow.mockResolvedValue({});
 
     const { result } = renderHook(() => useLogin(), { wrapper: wrapper() });
 
@@ -63,7 +63,7 @@ describe("useLogin", () => {
 
   it("surfaces thrown errors via the error field and resets loading", async () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    h.startLogin.mockRejectedValue(new Error("network"));
+    h.startFlow.mockRejectedValue(new Error("network"));
 
     const { result } = renderHook(() => useLogin(), { wrapper: wrapper() });
 
@@ -78,7 +78,7 @@ describe("useLogin", () => {
 
   it("dedupes concurrent start() calls", async () => {
     let resolveLogin: (value: unknown) => void = () => {};
-    h.startLogin.mockImplementation(
+    h.startFlow.mockImplementation(
       () => new Promise((resolve) => (resolveLogin = resolve)),
     );
 
@@ -93,7 +93,7 @@ describe("useLogin", () => {
       await Promise.resolve();
     });
 
-    expect(h.startLogin).toHaveBeenCalledTimes(1);
+    expect(h.startFlow).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       resolveLogin({});

--- a/packages/compose-react/src/hooks/use-login.ts
+++ b/packages/compose-react/src/hooks/use-login.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { loginService } from "@/services/login.service";
+import { loginService, type LoginStartParams } from "@/services/login.service";
 
 export interface UseLoginResult {
   start: () => void;
@@ -17,7 +17,7 @@ export function useLogin(): UseLoginResult {
 
   const mutation = useMutation({
     mutationKey: ["login", "start"],
-    mutationFn: loginService.startLogin,
+    mutationFn: (params: LoginStartParams) => loginService.startFlow(params),
     onSuccess: (data) => {
       if (data?.redirect_uri) {
         window.location.href = data.redirect_uri;

--- a/packages/compose-react/src/hooks/use-signup.test.tsx
+++ b/packages/compose-react/src/hooks/use-signup.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,18 +6,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => ({
   getSignUpSetting: vi.fn(),
   getRuntimeEnv: vi.fn(),
-  resolveBaseUrl: vi.fn(),
+  startFlow: vi.fn(),
 }));
 
-vi.mock("@/services/signup.service", () => ({ signUpService: h }));
+vi.mock("@/services/signup.service", () => ({
+  signUpService: { getSignUpSetting: h.getSignUpSetting },
+}));
+vi.mock("@/services/login.service", () => ({
+  loginService: { startFlow: h.startFlow },
+}));
 vi.mock("@/lib/runtime-env", () => ({ getRuntimeEnv: h.getRuntimeEnv }));
-vi.mock("@/lib/http/util", () => ({ resolveBaseUrl: h.resolveBaseUrl }));
 
-import { useSignUpAffordance } from "./use-signup";
+import { useSignUpAffordance, useSignUpRedirect } from "./use-signup";
 
 const wrapper = () => {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
   });
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
@@ -36,40 +43,25 @@ const setting = (isSignUpEnable: boolean) => ({
 beforeEach(() => {
   h.getSignUpSetting.mockReset();
   h.getRuntimeEnv.mockReset().mockReturnValue("tenant-1");
-  h.resolveBaseUrl.mockReset().mockReturnValue("https://iam.test");
+  h.startFlow.mockReset();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { origin: "https://app.test", href: "" },
+  });
 });
 
 describe("useSignUpAffordance", () => {
-  it("builds the tenant-scoped signup url when the tenant has signup enabled", async () => {
+  it("offers the control when the tenant has signup enabled", async () => {
     h.getSignUpSetting.mockResolvedValue(setting(true));
 
     const { result } = renderHook(() => useSignUpAffordance(), {
       wrapper: wrapper(),
     });
 
-    await waitFor(() =>
-      expect(result.current.signUpUrl).toBe(
-        "https://iam.test/oidc/signup/tenant-1",
-      ),
-    );
+    await waitFor(() => expect(result.current.canSignUp).toBe(true));
   });
 
-  it("trims a trailing slash off the IAM base url", async () => {
-    h.resolveBaseUrl.mockReturnValue("https://iam.test/");
-    h.getSignUpSetting.mockResolvedValue(setting(true));
-
-    const { result } = renderHook(() => useSignUpAffordance(), {
-      wrapper: wrapper(),
-    });
-
-    await waitFor(() =>
-      expect(result.current.signUpUrl).toBe(
-        "https://iam.test/oidc/signup/tenant-1",
-      ),
-    );
-  });
-
-  it("offers no url when the tenant has signup disabled", async () => {
+  it("offers nothing when the tenant has signup disabled", async () => {
     h.getSignUpSetting.mockResolvedValue(setting(false));
 
     const { result } = renderHook(() => useSignUpAffordance(), {
@@ -77,10 +69,10 @@ describe("useSignUpAffordance", () => {
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.signUpUrl).toBeUndefined();
+    expect(result.current.canSignUp).toBe(false);
   });
 
-  it("offers no url and asks nothing when no tenant is configured", async () => {
+  it("offers nothing and asks nothing when no tenant is configured", async () => {
     h.getRuntimeEnv.mockReturnValue("");
 
     const { result } = renderHook(() => useSignUpAffordance(), {
@@ -88,19 +80,7 @@ describe("useSignUpAffordance", () => {
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.signUpUrl).toBeUndefined();
-    expect(h.getSignUpSetting).not.toHaveBeenCalled();
-  });
-
-  it("offers no url and asks nothing when no IAM host is configured", async () => {
-    h.resolveBaseUrl.mockReturnValue("");
-
-    const { result } = renderHook(() => useSignUpAffordance(), {
-      wrapper: wrapper(),
-    });
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.signUpUrl).toBeUndefined();
+    expect(result.current.canSignUp).toBe(false);
     expect(h.getSignUpSetting).not.toHaveBeenCalled();
   });
 
@@ -112,6 +92,101 @@ describe("useSignUpAffordance", () => {
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.signUpUrl).toBeUndefined();
+    expect(result.current.canSignUp).toBe(false);
+  });
+});
+
+describe("useSignUpRedirect", () => {
+  it("asks IAM for the signup flow and navigates to what it returns", async () => {
+    h.startFlow.mockResolvedValue({
+      redirect_uri: "https://iam.test/oidc/signup/tenant-1?clientId=c",
+      flow: "signup",
+    });
+
+    const { result } = renderHook(() => useSignUpRedirect(), {
+      wrapper: wrapper(),
+    });
+    act(() => result.current.start());
+
+    await waitFor(() =>
+      expect(window.location.href).toBe(
+        "https://iam.test/oidc/signup/tenant-1?clientId=c",
+      ),
+    );
+    expect(h.startFlow).toHaveBeenCalledWith({
+      redirectUri: "https://app.test/login/callback",
+      flow: "signup",
+    });
+  });
+
+  it("accepts a signup url even when the server does not echo the flow", async () => {
+    h.startFlow.mockResolvedValue({
+      redirect_uri: "https://iam.test/oidc/signup/tenant-1",
+    });
+
+    const { result } = renderHook(() => useSignUpRedirect(), {
+      wrapper: wrapper(),
+    });
+    act(() => result.current.start());
+
+    await waitFor(() =>
+      expect(window.location.href).toBe(
+        "https://iam.test/oidc/signup/tenant-1",
+      ),
+    );
+  });
+
+  it("refuses to navigate when an older IAM answers with the authorize url", async () => {
+    // The `flow` parameter is unknown to that server, so it starts a login instead.
+    // Redirecting would look like a UI bug rather than a version mismatch.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    h.startFlow.mockResolvedValue({
+      redirect_uri: "https://iam.test/api/oidc/authorize?client_id=c",
+    });
+
+    const { result } = renderHook(() => useSignUpRedirect(), {
+      wrapper: wrapper(),
+    });
+    act(() => result.current.start());
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(window.location.href).toBe("");
+  });
+
+  it("surfaces the error when the request is rejected", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    h.startFlow.mockRejectedValue(new Error("invalid_client"));
+
+    const { result } = renderHook(() => useSignUpRedirect(), {
+      wrapper: wrapper(),
+    });
+    act(() => result.current.start());
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(window.location.href).toBe("");
+  });
+
+  it("ignores repeat clicks while a request is in flight", async () => {
+    h.startFlow.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () => resolve({ redirect_uri: "https://iam.test/oidc/signup/t" }),
+            10,
+          ),
+        ),
+    );
+
+    const { result } = renderHook(() => useSignUpRedirect(), {
+      wrapper: wrapper(),
+    });
+    act(() => {
+      result.current.start();
+      result.current.start();
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(h.startFlow).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/compose-react/src/hooks/use-signup.ts
+++ b/packages/compose-react/src/hooks/use-signup.ts
@@ -1,49 +1,111 @@
-import { useQuery } from "@tanstack/react-query";
-import { resolveBaseUrl } from "@/lib/http/util";
+import { useCallback, useRef } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { getRuntimeEnv } from "@/lib/runtime-env";
+import { loginService } from "@/services/login.service";
 import { signUpService } from "@/services/signup.service";
 
 export interface UseSignUpAffordanceResult {
-  /** Absolute URL of the IAM signup page, or `undefined` when signup is closed. */
-  signUpUrl?: string;
+  /** Whether the tenant offers a signup page worth linking to. */
+  canSignUp: boolean;
   isLoading: boolean;
 }
 
-const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
-
 /**
- * Resolves whether this tenant offers self-service signup, and where to send
- * people if it does.
+ * Whether to render a Sign up control at all.
  *
- * Two conditions have to hold, and both fail closed:
+ * Asked before anyone clicks, so it stays a settings lookup rather than an initiate
+ * call. It fails closed: an unreachable or unauthorized settings endpoint means "no
+ * affordance", not a retry storm on an unauthenticated page.
  *
- * 1. A tenant and an IAM host are configured. blocks-iam only routes
- *    `/oidc/signup/:tenantId` — the un-scoped `/oidc/signup` is not a route —
- *    so without a tenant there is no link worth rendering.
- * 2. The tenant has signup switched on. Linking regardless would drop people
- *    on a signup page that renders no form.
+ * `isSignUpEnable` is already the OR of the email and SSO flags server-side, so there
+ * is nothing further to combine here. The one case it cannot see — SSO signup enabled
+ * with no social provider configured, which renders an empty card — is caught by IAM
+ * when the button is actually clicked.
  */
 export function useSignUpAffordance(): UseSignUpAffordanceResult {
   const tenantId = getRuntimeEnv("BLOCKS_X_BLOCKS_KEY");
-  const iamBaseUrl = resolveBaseUrl("user");
-  const isConfigured = !!tenantId && !!iamBaseUrl;
 
   const { data, isLoading } = useQuery({
     queryKey: ["sign-up-setting", tenantId],
     queryFn: () => signUpService.getSignUpSetting(),
-    enabled: isConfigured,
-    // An unreachable or unauthorized settings call means "no affordance", not a
-    // retry storm on an unauthenticated page.
+    enabled: !!tenantId,
     retry: false,
     staleTime: 5 * 60 * 1000,
   });
 
-  const isEnabled = isConfigured && (data?.isSignUpEnable ?? false);
+  return {
+    canSignUp: !!tenantId && (data?.isSignUpEnable ?? false),
+    isLoading: !!tenantId && isLoading,
+  };
+}
+
+export interface UseSignUpRedirectResult {
+  start: () => void;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Sends the user to IAM's signup page.
+ *
+ * Deliberately the same shape as `useLogin`: ask IAM where to go, then go there. The
+ * URL is never built here, because IAM has to validate the clientId and redirect URI
+ * against the database first — the redirect URI in particular rides all the way into
+ * the activation email, and an unvalidated one silently returns the user to whichever
+ * client happens to be first for the tenant.
+ */
+export function useSignUpRedirect(): UseSignUpRedirectResult {
+  // Same synchronous guard as useLogin: React batches the state update from `mutate()`,
+  // so `isPending` has not flipped yet within the tick the first click fires in.
+  const inFlight = useRef(false);
+
+  const mutation = useMutation({
+    mutationKey: ["signup", "start"],
+    mutationFn: async () => {
+      const data = await loginService.startFlow({
+        redirectUri: `${window.location.origin}/login/callback`,
+        flow: "signup",
+      });
+
+      // An IAM that predates the `flow` parameter ignores it and answers with the
+      // authorize URL, which would drop the user on the login page looking like a UI
+      // bug rather than a version mismatch. We know what we asked for, so check what
+      // came back before navigating anywhere.
+      const isSignUpUrl =
+        data?.flow === "signup" ||
+        !!data?.redirect_uri?.includes("/oidc/signup/");
+
+      if (!data?.redirect_uri || !isSignUpUrl) {
+        throw new Error(
+          "Signup is unavailable — the identity service did not return a signup URL",
+        );
+      }
+
+      return data.redirect_uri;
+    },
+    onSuccess: (redirectUri) => {
+      window.location.href = redirectUri;
+    },
+    onError: (err) => {
+      console.error("Error initiating signup:", err);
+    },
+    onSettled: () => {
+      inFlight.current = false;
+    },
+  });
+
+  const start = useCallback(() => {
+    if (inFlight.current) return;
+    if (mutation.isPending) return;
+    inFlight.current = true;
+    mutation.mutate();
+  }, [mutation]);
+
+  const error = mutation.error instanceof Error ? mutation.error : null;
 
   return {
-    signUpUrl: isEnabled
-      ? `${trimTrailingSlash(iamBaseUrl)}/oidc/signup/${encodeURIComponent(tenantId)}`
-      : undefined,
-    isLoading: isConfigured && isLoading,
+    start,
+    isLoading: mutation.isPending,
+    error,
   };
 }

--- a/packages/compose-react/src/pages/login/blocks-login.tsx
+++ b/packages/compose-react/src/pages/login/blocks-login.tsx
@@ -15,7 +15,9 @@ export const BlocksLoginPage = ({
   loginLabel = "Log in to your account",
   docsUrl = "https://docs.seliseblocks.com/",
   footerLink = { label: "Visit Blocks", url: "https://seliseblocks.com" },
-  signUpUrl,
+  showSignUp = false,
+  onSignUp,
+  isSignUpLoading = false,
   carouselItems,
 }: BlocksLoginPageProps) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -180,11 +182,16 @@ export const BlocksLoginPage = ({
               </svg>
             </a>
           </div>
-          {signUpUrl && (
+          {showSignUp && (
             <p className="cta-signup">
               Not a member?{" "}
-              <a href={signUpUrl} className="cta-signup-link">
-                Sign up
+              <button
+                type="button"
+                onClick={onSignUp}
+                disabled={isSignUpLoading}
+                className="cta-signup-link"
+              >
+                {isSignUpLoading ? "Redirecting…" : "Sign up"}
                 <svg
                   width="11"
                   height="11"
@@ -195,7 +202,7 @@ export const BlocksLoginPage = ({
                 >
                   <path d="M5 12h14M12 5l7 7-7 7" />
                 </svg>
-              </a>
+              </button>
             </p>
           )}
         </div>

--- a/packages/compose-react/src/pages/login/login.styles.ts
+++ b/packages/compose-react/src/pages/login/login.styles.ts
@@ -328,10 +328,15 @@ export const blocksLoginStyles = `
   display: inline-flex; align-items: center; gap: 6px;
   color: var(--accent2); text-decoration: none; font-weight: 600;
   transition: gap 0.25s var(--ease-out-expo), text-shadow 0.25s ease;
+  /* Renders as a button: it asks IAM for the signup URL rather than linking to one,
+     so the UA button styling has to be reset back to the inline-link look. */
+  background: none; border: 0; padding: 0; margin: 0;
+  font: inherit; font-weight: 600; cursor: pointer;
 }
-.blocksLogin-page .cta-signup-link:hover { gap: 10px; text-shadow: 0 0 10px var(--accent2-glow); }
+.blocksLogin-page .cta-signup-link:disabled { cursor: default; opacity: 0.7; }
+.blocksLogin-page .cta-signup-link:hover:not(:disabled) { gap: 10px; text-shadow: 0 0 10px var(--accent2-glow); }
 .blocksLogin-page .cta-signup-link svg { transition: transform 0.25s var(--ease-out-expo); }
-.blocksLogin-page .cta-signup-link:hover svg { transform: translateX(3px); }
+.blocksLogin-page .cta-signup-link:hover:not(:disabled) svg { transform: translateX(3px); }
 
 .blocksLogin-page .col-right {
   display: flex; flex-direction: column; min-height: 0; overflow: hidden;

--- a/packages/compose-react/src/pages/login/login.test.tsx
+++ b/packages/compose-react/src/pages/login/login.test.tsx
@@ -5,7 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
   name: "blocks-logic",
-  startLogin: vi.fn(),
+  startFlow: vi.fn(),
+  getSignUpSetting: vi.fn(),
+}));
+
+vi.mock("@/services/signup.service", () => ({
+  signUpService: { getSignUpSetting: h.getSignUpSetting },
 }));
 
 vi.mock("@/hooks/use-blocks-app-config-store", () => ({
@@ -14,22 +19,28 @@ vi.mock("@/hooks/use-blocks-app-config-store", () => ({
   ) => selector({ getConfig: () => ({ name: h.name }) }),
 }));
 vi.mock("@/services/login.service", () => ({
-  loginService: { startLogin: h.startLogin },
+  loginService: { startFlow: h.startFlow },
 }));
 vi.mock("./blocks-login", () => ({
   BlocksLoginPage: ({
     name,
     onLogin,
     isLoading,
+    showSignUp,
+    onSignUp,
   }: {
     name: string;
     onLogin: () => void;
     isLoading: boolean;
+    showSignUp?: boolean;
+    onSignUp?: () => void;
   }) => (
     <div>
       <span data-testid="name">{name}</span>
       <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="show-signup">{String(showSignUp)}</span>
       <button onClick={onLogin}>login</button>
+      <button onClick={onSignUp}>signup</button>
     </div>
   ),
 }));
@@ -56,7 +67,14 @@ describe("LoginPage", () => {
       configurable: true,
       value: { origin: "https://app.test", href: "" },
     });
-    h.startLogin.mockResolvedValue({});
+    h.startFlow.mockResolvedValue({});
+    h.getSignUpSetting.mockResolvedValue({
+      isSignUpEnable: true,
+      isEmailPasswordSignUpEnabled: true,
+      isSSoSignUpEnabled: false,
+      defaultRolesForNewUser: [],
+      defaultPermissionsForNewUser: [],
+    });
   });
 
   it("renders the login page with the app name", () => {
@@ -66,7 +84,7 @@ describe("LoginPage", () => {
   });
 
   it("triggers login and redirects to the initiate response url", async () => {
-    h.startLogin.mockResolvedValue({ redirect_uri: "https://idp/authorize" });
+    h.startFlow.mockResolvedValue({ redirect_uri: "https://idp/authorize" });
 
     render(<LoginPage />, { wrapper: wrapper() });
     fireEvent.click(screen.getByText("login"));
@@ -74,13 +92,13 @@ describe("LoginPage", () => {
     await waitFor(() =>
       expect(window.location.href).toBe("https://idp/authorize"),
     );
-    expect(h.startLogin.mock.calls[0]?.[0]).toEqual({
+    expect(h.startFlow.mock.calls[0]?.[0]).toEqual({
       redirectUri: "https://app.test/login/callback",
     });
   });
 
   it("stops the loading state when no redirect url is returned", async () => {
-    h.startLogin.mockResolvedValue({});
+    h.startFlow.mockResolvedValue({});
 
     render(<LoginPage />, { wrapper: wrapper() });
     fireEvent.click(screen.getByText("login"));
@@ -91,9 +109,29 @@ describe("LoginPage", () => {
     expect(window.location.href).toBe("");
   });
 
+  it("asks for the signup flow and redirects to the signup page", async () => {
+    h.startFlow.mockResolvedValue({
+      redirect_uri: "https://iam.test/oidc/signup/tenant-1",
+      flow: "signup",
+    });
+
+    render(<LoginPage />, { wrapper: wrapper() });
+    fireEvent.click(screen.getByText("signup"));
+
+    await waitFor(() =>
+      expect(window.location.href).toBe(
+        "https://iam.test/oidc/signup/tenant-1",
+      ),
+    );
+    expect(h.startFlow.mock.calls[0]?.[0]).toEqual({
+      redirectUri: "https://app.test/login/callback",
+      flow: "signup",
+    });
+  });
+
   it("logs and resets loading when the request throws", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
-    h.startLogin.mockRejectedValue(new Error("network"));
+    h.startFlow.mockRejectedValue(new Error("network"));
 
     render(<LoginPage />, { wrapper: wrapper() });
     fireEvent.click(screen.getByText("login"));

--- a/packages/compose-react/src/pages/login/login.tsx
+++ b/packages/compose-react/src/pages/login/login.tsx
@@ -1,20 +1,24 @@
 import { useBlocksAppConfigStore } from "@/hooks/use-blocks-app-config-store";
 import { useLogin } from "@/hooks/use-login";
-import { useSignUpAffordance } from "@/hooks/use-signup";
+import { useSignUpAffordance, useSignUpRedirect } from "@/hooks/use-signup";
 import { BlocksLoginPage } from "./blocks-login";
 import { BLOCKS_PRODUCTS } from "./login.constant";
 
 export const LoginPage = () => {
   const config = useBlocksAppConfigStore((state) => state.getConfig());
   const { start, isLoading } = useLogin();
-  const { signUpUrl } = useSignUpAffordance();
+  const { canSignUp } = useSignUpAffordance();
+  const { start: startSignUp, isLoading: isSignUpLoading } =
+    useSignUpRedirect();
 
   return (
     <BlocksLoginPage
       name={config.name}
       onLogin={start}
       isLoading={isLoading}
-      signUpUrl={signUpUrl}
+      showSignUp={canSignUp}
+      onSignUp={startSignUp}
+      isSignUpLoading={isSignUpLoading}
       carouselItems={BLOCKS_PRODUCTS}
     />
   );

--- a/packages/compose-react/src/pages/login/login.types.ts
+++ b/packages/compose-react/src/pages/login/login.types.ts
@@ -38,8 +38,11 @@ export interface BlocksLoginPageProps {
   loginLabel?: string;
   docsUrl?: string;
   footerLink?: { label: string; url: string };
-  /** IAM signup page URL. Omitted when the tenant has signup switched off. */
-  signUpUrl?: string;
+  /** Whether to render the Sign up control. False when the tenant has signup off. */
+  showSignUp?: boolean;
+  /** Asks IAM where the signup page is, then navigates there. */
+  onSignUp?: () => void | Promise<void>;
+  isSignUpLoading?: boolean;
   // Was LoginCarouselItem[] — widened to accept either shape
   carouselItems?: (LoginCarouselItem | BlocksProduct)[];
 }

--- a/packages/compose-react/src/services/login.service.test.ts
+++ b/packages/compose-react/src/services/login.service.test.ts
@@ -20,9 +20,9 @@ beforeEach(() => {
   };
 });
 
-describe("LoginService.startLogin", () => {
+describe("LoginService.startFlow", () => {
   it("calls the initiate endpoint with the redirect uri, client id and blocks key", async () => {
-    await loginService.startLogin({ redirectUri: "https://app/cb" });
+    await loginService.startFlow({ redirectUri: "https://app/cb" });
 
     const [url, headers] = c.get.mock.calls[0] ?? [];
     expect(url).toContain(IAM_ENDPOINTS.INITIATE);
@@ -35,7 +35,7 @@ describe("LoginService.startLogin", () => {
   it("omits the X-Blocks-Key header when the key is missing", async () => {
     h.env = { BLOCKS_OIDC_CLIENT_ID: "cid" };
 
-    await loginService.startLogin({ redirectUri: "https://app/cb" });
+    await loginService.startFlow({ redirectUri: "https://app/cb" });
 
     const headers = c.get.mock.calls[0]?.[1];
     expect(headers).toEqual({});
@@ -45,7 +45,25 @@ describe("LoginService.startLogin", () => {
     c.get.mockResolvedValue({ redirect_uri: "https://idp/go" });
 
     await expect(
-      loginService.startLogin({ redirectUri: "https://app/cb" }),
+      loginService.startFlow({ redirectUri: "https://app/cb" }),
     ).resolves.toEqual({ redirect_uri: "https://idp/go" });
+  });
+
+  it("sends no flow parameter for login, so the request is unchanged", async () => {
+    await loginService.startFlow({
+      redirectUri: "https://app/cb",
+      flow: "login",
+    });
+
+    expect(c.get.mock.calls[0]?.[0]).not.toContain("flow=");
+  });
+
+  it("asks for the signup flow when requested", async () => {
+    await loginService.startFlow({
+      redirectUri: "https://app/cb",
+      flow: "signup",
+    });
+
+    expect(c.get.mock.calls[0]?.[0]).toContain("flow=signup");
   });
 });

--- a/packages/compose-react/src/services/login.service.ts
+++ b/packages/compose-react/src/services/login.service.ts
@@ -2,16 +2,29 @@ import { IAM_ENDPOINTS } from "@/constants/endpoint.constant";
 import { iamClient } from "@/lib/http/instances";
 import { getRuntimeEnv } from "@/lib/runtime-env";
 
+/** Which page the initiate response should point at. */
+export type AuthFlow = "login" | "signup";
+
 export interface LoginStartParams {
   redirectUri: string;
+  /** Defaults to `login`, which is sent as no `flow` parameter at all. */
+  flow?: AuthFlow;
 }
 
 export interface LoginStartResponse {
   redirect_uri?: string;
+  /** Echoed by IAM for `flow=signup`. Absent on servers that predate the parameter. */
+  flow?: string;
 }
 
 class LoginService {
-  startLogin({ redirectUri }: LoginStartParams): Promise<LoginStartResponse> {
+  // One request shape serves both flows — the client, the tenant and the redirect URI
+  // are identical, and only the page IAM points back at differs. `flow` is appended
+  // only when it is signup, so a login request goes out byte-identical to before.
+  startFlow({
+    redirectUri,
+    flow,
+  }: LoginStartParams): Promise<LoginStartResponse> {
     const blocksKey = getRuntimeEnv("BLOCKS_X_BLOCKS_KEY");
     const clientId = getRuntimeEnv("BLOCKS_OIDC_CLIENT_ID");
 
@@ -20,6 +33,8 @@ class LoginService {
       clientId,
       redirectUri,
     });
+    if (flow === "signup") params.set("flow", flow);
+
     const headers: Record<string, string> = {};
     if (blocksKey) headers["X-Blocks-Key"] = blocksKey;
 


### PR DESCRIPTION
The Sign up button linked to a URL assembled in the browser -- {iamBase}/oidc/signup/{tenantId} with no query string at all. Two things were wrong with that. The clientId and redirect_uri never reached the signup form, so the activation email fell back to whichever OIDC client sorts first for the tenant and returned people to the wrong project. And nothing validated the client, because no request was made.

Both are fixed by asking IAM where to go, exactly as the Login button already does: startFlow gains a `flow` parameter, and useSignUpRedirect mirrors useLogin down to the inFlight ref that guards against the repeat clicks React's batching lets through.

useSignUpAffordance no longer returns a URL -- there is none to hand out before the click -- so it returns { canSignUp, isLoading } and stays a settings lookup, which is still what decides whether the control renders. Its gate is unchanged: isSignUpEnable is already the OR of the email and SSO flags server-side, so there was nothing to tighten.

An IAM that predates the parameter ignores it and answers with the authorize URL, which would drop people on the login page looking like a UI bug. We know what we asked for, so the response is checked before navigating and surfaces an error instead.

The control becomes a button rather than an anchor, with the UA styling reset back to the inline-link look it had.