### PR TITLE
fix: gate project rendering on the route's tenant, not a boolean

### DIFF
--- a/packages/compose-react/src/guards/impersonation.guard.test.tsx
+++ b/packages/compose-react/src/guards/impersonation.guard.test.tsx
@@ -1,11 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+type Claim = { tenantId: string; tabId: string; ts: number };
 
 const h = vi.hoisted(() => ({
   status: { data: undefined as unknown, isLoading: true, isSuccess: false },
   stopMutate: vi.fn(),
   startMutate: vi.fn(),
   projects: { data: undefined as unknown },
+  claimTenant: vi.fn(),
+  currentOwner: null as { tenantId: string; tabId: string; ts: number } | null,
+  onClaim: undefined as
+    | ((claim: { tenantId: string; tabId: string; ts: number }) => void)
+    | undefined,
+}));
+
+// Driving the subscription callback directly keeps these tests about the guard's use of tenant
+// ownership rather than about BroadcastChannel's semantics under jsdom.
+vi.mock("@/lib/tenant-ownership", () => ({
+  claimTenant: h.claimTenant,
+  readCurrentOwner: () => h.currentOwner,
+  subscribeToTenantClaims: (cb: (claim: Claim) => void) => {
+    h.onClaim = cb;
+    return () => {
+      h.onClaim = undefined;
+    };
+  },
 }));
 
 vi.mock("@/hooks/use-impersonation", () => ({
@@ -36,6 +57,9 @@ beforeEach(() => {
   h.stopMutate.mockReset().mockResolvedValue(undefined);
   h.startMutate.mockReset().mockResolvedValue(undefined);
   h.projects = { data: undefined };
+  h.claimTenant.mockReset();
+  h.currentOwner = null;
+  h.onClaim = undefined;
 });
 
 describe("ImpersonationChecker", () => {
@@ -110,5 +134,101 @@ describe("ImpersonationSynchronizer", () => {
       </ImpersonationSynchronizer>,
     );
     expect(screen.getByText("child")).toBeInTheDocument();
+  });
+});
+
+describe("ImpersonationSynchronizer inside a project route", () => {
+  const P1 = { itemId: "p1", tenantId: "t1", tenantGroupId: "tg1" };
+
+  const renderAt = (itemId: string) =>
+    render(
+      <MemoryRouter initialEntries={[`/app/${itemId}`]}>
+        <Routes>
+          <Route
+            path="/app/:itemId"
+            element={
+              <ImpersonationSynchronizer>
+                <div>child</div>
+              </ImpersonationSynchronizer>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+  it("renders children when the route's tenant is the impersonated tenant", () => {
+    useProjectStore.getState().setProjects([P1] as never);
+    useImpersonateStore.getState().setImpersonation(true, "orig", "t1");
+
+    renderAt("p1");
+
+    expect(screen.getByText("child")).toBeInTheDocument();
+  });
+
+  it("never renders children while impersonating a different tenant", async () => {
+    useProjectStore.getState().setProjects([P1] as never);
+    // Impersonated somewhere else — the shape another tab's claim leaves behind.
+    useImpersonateStore.getState().setImpersonation(true, "orig", "t2");
+
+    renderAt("p1");
+
+    // The regression this guards: the old gate read `isImpersonated`, which is true here.
+    expect(screen.queryByText("child")).toBeNull();
+    await waitFor(() =>
+      expect(h.startMutate).toHaveBeenCalledWith({ targeted_tenant_id: "t1" }),
+    );
+  });
+
+  it("waits, rather than treating an unresolvable route as a mismatch", () => {
+    // Projects list not hydrated yet: a cold first visit, or a project created elsewhere.
+    useImpersonateStore.getState().setImpersonation(true, "orig", "t1");
+
+    renderAt("p1");
+
+    expect(screen.queryByText("child")).toBeNull();
+    // Must not re-impersonate on a guess while the route is unresolved.
+    expect(h.startMutate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed impersonation and does not retry on its own", async () => {
+    h.startMutate.mockRejectedValue(new Error("nope"));
+    useProjectStore.getState().setProjects([P1] as never);
+    useImpersonateStore.getState().setImpersonation(true, "orig", "t2");
+
+    renderAt("p1");
+
+    expect(
+      await screen.findByText("Could not open this project"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("child")).toBeNull();
+    // Previously the failure was swallowed and the effect's deps froze; assert we neither loop
+    // nor silently give up and render the wrong tenant.
+    expect(h.startMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("detaches when another tab claims a different tenant", async () => {
+    useProjectStore.getState().setProjects([P1] as never);
+    useImpersonateStore.getState().setImpersonation(true, "orig", "t1");
+
+    renderAt("p1");
+    expect(screen.getByText("child")).toBeInTheDocument();
+
+    act(() => {
+      h.onClaim?.({ tenantId: "t2", tabId: "another-tab", ts: Date.now() });
+    });
+
+    expect(
+      await screen.findByText("This project is open in another tab"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("child")).toBeNull();
+  });
+
+  it("claims the cookie for other tabs after a successful retarget", async () => {
+    useProjectStore.getState().setProjects([P1] as never);
+    useImpersonateStore.getState().setImpersonation(true, "orig", "t2");
+
+    renderAt("p1");
+
+    await waitFor(() => expect(h.claimTenant).toHaveBeenCalledWith("t1"));
   });
 });

--- a/packages/compose-react/src/guards/impersonation.guard.tsx
+++ b/packages/compose-react/src/guards/impersonation.guard.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components";
 import { AppLoadingSpinner } from "@/components/common/loader-spinner";
 import {
   useImpersonationStatusChecker,
@@ -6,11 +7,15 @@ import {
 } from "@/hooks/use-impersonation";
 import { useGetProjects } from "@/hooks/use-project";
 import { HttpError } from "@/lib/http/error";
-import type { ImpersonationRequest } from "@/models";
+import {
+  claimTenant,
+  readCurrentOwner,
+  subscribeToTenantClaims,
+} from "@/lib/tenant-ownership";
 import { projectService } from "@/services/project.service";
 import { useImpersonateStore, useProjectStore } from "@/store";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useParams } from "react-router";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router";
 
 export const ImpersonationChecker = ({
   children,
@@ -75,13 +80,59 @@ export function ImpersonationTerminator({
   return <>{children}</>;
 }
 
+/**
+ * Terminal state for a tab that must not render project data: either a repair failed, or another
+ * tab has taken the shared cookie. Both need the same shape -- say what happened, offer the single
+ * action that resolves it, and always leave a way back to the console.
+ */
+function ImpersonationBlocked({
+  title,
+  description,
+  actionLabel,
+  onAction,
+  consolePath,
+}: {
+  title: string;
+  description: string;
+  actionLabel: string;
+  onAction: () => void;
+  consolePath: string;
+}) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex h-full min-h-[320px] w-full flex-col items-center justify-center gap-4 p-8 text-center">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-base font-semibold">{title}</h2>
+        <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="flex flex-row items-center gap-2">
+        <Button onClick={onAction}>{actionLabel}</Button>
+        <Button variant="outline" onClick={() => navigate(consolePath)}>
+          Back to console
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function ImpersonationSynchronizer({
   children,
+  consolePath = "/app/console",
 }: {
   children: React.ReactNode;
+  /** Where the escape hatches lead. Matches `DashboardRoute`'s own default. */
+  consolePath?: string;
 }) {
-  const { impersonate, isImpersonated, impersonatedTenantId } =
-    useImpersonateStore();
+  const {
+    impersonate,
+    isImpersonated,
+    impersonatedTenantId,
+    impersonationError,
+    isDetached,
+    setImpersonationError,
+    setDetached,
+  } = useImpersonateStore();
   const { mutateAsync } = useStartImpersonation();
   const { data: _data } = useGetProjects({ enabled: true });
   const { selectedProject, setSelectedProject, projects, setTenantGroup } =
@@ -90,17 +141,37 @@ export function ImpersonationSynchronizer({
   const [isImpersonating, setIsImpersonating] = useState(false);
   const { itemId } = useParams<{ itemId: string }>();
 
+  /**
+   * The tenant this tab is *supposed* to be in, derived from the URL rather than from
+   * `selectedProject`.
+   *
+   * The route is the only per-tab source of truth available. `selectedProject` was persisted to
+   * localStorage, so it could arrive from a different tab entirely; the route cannot. The projects
+   * list hydrates synchronously from storage, so this resolves on the first render in every case
+   * except a genuinely cold first visit.
+   *
+   * `null` means "cannot resolve yet", which is emphatically not "wrong tenant" -- a project
+   * created in another session simply is not in this tab's copy of the list. Conflating the two
+   * would bounce people out of perfectly valid deep links.
+   */
+  const routeTenantId = useMemo(() => {
+    if (!itemId) return null;
+    return projects.find((p) => p.itemId === itemId)?.tenantId ?? null;
+  }, [itemId, projects]);
+
   // Keep refs in sync so runImpersonation always reads latest values
   // without needing to be in its own dependency array
   const impersonatedTenantIdRef = useRef(impersonatedTenantId);
   const selectedProjectRef = useRef(selectedProject);
   const projectsRef = useRef(projects);
+  const routeTenantIdRef = useRef(routeTenantId);
 
   impersonatedTenantIdRef.current = impersonatedTenantId;
   selectedProjectRef.current = selectedProject;
   projectsRef.current = projects;
+  routeTenantIdRef.current = routeTenantId;
 
-  // Seed effect — unchanged logic, correct field match
+  // Seed effect — keeps the visible project in step with the route.
   useEffect(() => {
     if (!itemId || !projects.length) return;
     if (selectedProject?.itemId === itemId) return;
@@ -130,57 +201,145 @@ export function ImpersonationSynchronizer({
   // This means it never recreates due to selectedProject/projects/impersonatedTenantId
   // changing, which was causing the double-fire in Safari.
   const runImpersonation = useCallback(async () => {
-    const impersonatedTenantId = impersonatedTenantIdRef.current;
-    const selectedProject = selectedProjectRef.current;
-    const projects = projectsRef.current;
+    const targetTenantId = routeTenantIdRef.current;
+    const currentTenantId = impersonatedTenantIdRef.current;
+    const knownProjects = projectsRef.current;
 
     isTriggering.current = true;
     setIsImpersonating(true);
     try {
-      // Cold-start: token already impersonated but store empty (projects still loading)
-      if (impersonatedTenantId && !selectedProject) {
-        let project = projects.find((p) => p.tenantId === impersonatedTenantId);
-        if (!project) project = await getImpersonatedProject();
-        if (!project) {
-          isTriggering.current = false;
-          setIsImpersonating(false);
-          return;
+      // Cold start: the token is already impersonated but the route cannot be resolved, because
+      // this tab has no copy of the projects list yet. Ask the server which project the current
+      // token belongs to rather than re-impersonating on a guess.
+      if (!targetTenantId) {
+        if (currentTenantId && !selectedProjectRef.current) {
+          const project =
+            knownProjects.find((p) => p.tenantId === currentTenantId) ??
+            (await getImpersonatedProject());
+          if (project) {
+            setSelectedProject(project);
+            setTenantGroup(project.tenantGroupId);
+          }
         }
-        setSelectedProject(project);
-        setTenantGroup(project.tenantGroupId);
-        isTriggering.current = false;
-        setIsImpersonating(false);
         return;
       }
 
-      // Project-switch: selectedProject was set by seed effect or user action
-      const payload: ImpersonationRequest = {
-        targeted_tenant_id: selectedProject?.tenantId || "",
-      };
-      const blocksKey = window.process?.env.BLOCKS_X_BLOCKS_KEY || "";
-      await mutateAsync(payload);
-      impersonate(payload.targeted_tenant_id, blocksKey);
-      isTriggering.current = false;
-      setIsImpersonating(false);
+      // Retarget straight to the route's tenant. Deliberately not stop-then-start: the impersonate
+      // endpoint already retargets an existing session, and stopping first costs two extra round
+      // trips and leaves the cookie holding a root token in between.
+      await mutateAsync({ targeted_tenant_id: targetTenantId });
+      impersonate(
+        targetTenantId,
+        window.process?.env.BLOCKS_X_BLOCKS_KEY || "",
+      );
+      // This tab now owns the shared cookie; tell the others before they fetch under it.
+      claimTenant(targetTenantId);
+
+      const project = knownProjects.find((p) => p.tenantId === targetTenantId);
+      if (project) {
+        setSelectedProject(project);
+        setTenantGroup(project.tenantGroupId);
+      }
     } catch (error) {
-      console.error("Error during impersonation:", error);
+      // Recorded, not swallowed. Losing this used to leave the store pinned to the previous
+      // project's tenant while the route kept pointing at this one, which froze the trigger effect
+      // below: its dependencies stopped changing, so it never ran again and the page kept rendering
+      // another tenant's data indefinitely, with no error anywhere.
+      setImpersonationError(error);
+    } finally {
       isTriggering.current = false;
       setIsImpersonating(false);
     }
-  }, [mutateAsync, impersonate, setSelectedProject, setTenantGroup]); // only truly stable deps
+  }, [
+    mutateAsync,
+    impersonate,
+    setSelectedProject,
+    setTenantGroup,
+    setImpersonationError,
+  ]);
 
-  // Trigger effect only depends on the two scalar values that signal a mismatch.
-  // runImpersonation is intentionally absent — it's now stable and reads via refs.
-  useEffect(() => {
-    if (!impersonatedTenantId && !selectedProject?.tenantId) return;
-    if (isTriggering.current) return;
-    if (impersonatedTenantId === selectedProject?.tenantId) return;
+  const retry = useCallback(() => {
+    setImpersonationError(null);
+    setDetached(false);
     void runImpersonation();
-  }, [impersonatedTenantId, selectedProject?.tenantId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [runImpersonation, setImpersonationError, setDetached]);
+
+  // Another tab taking the cookie is the one event this tab cannot observe for itself: the token is
+  // HttpOnly, and the status endpoint is only refetched on window focus.
+  useEffect(() => {
+    const owner = readCurrentOwner();
+    if (owner && routeTenantId && owner.tenantId !== routeTenantId) {
+      setDetached(true);
+    }
+    return subscribeToTenantClaims((claim) => {
+      const mine = routeTenantIdRef.current;
+      if (!mine) return;
+      setDetached(claim.tenantId !== mine);
+    });
+  }, [routeTenantId, setDetached]);
+
+  useEffect(() => {
+    if (!itemId) return;
+    if (isTriggering.current) return;
+    // A failed repair and a detached tab are both terminal: retrying on every render would hammer
+    // the endpoint and flicker the UI. Both clear only through an explicit user action.
+    if (impersonationError || isDetached) return;
+
+    const needsColdStart =
+      !routeTenantId && !!impersonatedTenantId && !selectedProject;
+    const needsRetarget =
+      !!routeTenantId && routeTenantId !== impersonatedTenantId;
+    if (!needsColdStart && !needsRetarget) return;
+
+    void runImpersonation();
+  }, [
+    itemId,
+    routeTenantId,
+    impersonatedTenantId,
+    selectedProject,
+    impersonationError,
+    isDetached,
+    runImpersonation,
+  ]);
 
   if (isImpersonating) return <AppLoadingSpinner />;
-  if (!isImpersonated || isTriggering.current) {
-    return itemId ? <AppLoadingSpinner /> : null;
+
+  // Outside a project scope there is no tenant to agree about; preserve the original behaviour.
+  if (!itemId) {
+    if (!isImpersonated || isTriggering.current) return null;
+    return <>{children}</>;
   }
+
+  if (impersonationError) {
+    return (
+      <ImpersonationBlocked
+        title="Could not open this project"
+        description="We could not switch your session to this project. Retry, or go back to the console and pick a project again."
+        actionLabel="Retry"
+        onAction={retry}
+        consolePath={consolePath}
+      />
+    );
+  }
+
+  if (isDetached) {
+    return (
+      <ImpersonationBlocked
+        title="This project is open in another tab"
+        description="Your session can only be in one project at a time. Use this tab instead, or return to the console."
+        actionLabel="Use this tab"
+        onAction={retry}
+        consolePath={consolePath}
+      />
+    );
+  }
+
+  // The gate that matters. It used to read `isImpersonated`, a boolean that stays true while
+  // impersonating the WRONG project -- which is how one tenant's rows came to be rendered under
+  // another project's name. Nothing renders unless the tenant we are in is the tenant the URL
+  // asked for.
+  if (!routeTenantId) return <AppLoadingSpinner />;
+  if (routeTenantId !== impersonatedTenantId) return <AppLoadingSpinner />;
+
   return <>{children}</>;
 }

--- a/packages/compose-react/src/lib/http/client.ts
+++ b/packages/compose-react/src/lib/http/client.ts
@@ -28,9 +28,20 @@ export class HttpClient {
   private autoRedirectOnAuthFailure: boolean;
   private onError?: (failure: HttpRequestFailure) => void;
 
-  // Per-instance, not module-level — two HttpClient instances pointed at
-  // different baseURLs/tenants must never share a refresh lock.
-  private refreshPromise: Promise<void> | null = null;
+  // Keyed by refresh target, not per instance.
+  //
+  // The lock used to be an instance field, on the reasoning that two clients pointed at different
+  // baseURLs or tenants must not share one. That reasoning is sound but did not describe the actual
+  // instances: iamClient, logicClient and notificationClient all carry the same blocks key, and
+  // performRefresh always refreshes against IAM via resolveBaseUrl("user") using the same
+  // HttpOnly refresh cookie and therefore the same server-side token lineage.
+  //
+  // So a single window-focus event could fire three concurrent rotations of one refresh token. The
+  // server rotates an impersonated lineage twice more per refresh, so up to six writes raced; the
+  // losers came back invalid_grant, and handleRefreshFailure turned that into a forced redirect to
+  // /login. Keying by the refresh target keeps the original guarantee for clients that genuinely
+  // differ while collapsing the ones that do not into one in-flight refresh.
+  private static readonly refreshPromises = new Map<string, Promise<void>>();
 
   constructor(config: HttpClientConfig) {
     this.baseURL = config.baseURL;
@@ -103,16 +114,26 @@ export class HttpClient {
     return JSON.stringify(body);
   }
 
-  // Ensures only one refresh request is ever in flight per instance.
-  // Concurrent 401s from get/post/.../stream all await this same
-  // promise instead of each independently racing to refresh.
+  // Identifies the credential a refresh actually rotates: the IAM base URL performRefresh posts to,
+  // plus the tenant key it sends. Two clients that resolve to the same pair are rotating the same
+  // token and must share one lock; two that do not are independent and must not.
+  private refreshLockKey(): string {
+    return `${resolveBaseUrl("user")}::${this.getBlocksKey()}`;
+  }
+
+  // Ensures only one refresh request is ever in flight per refresh target.
+  // Concurrent 401s from get/post/.../stream — across every client sharing
+  // that target — all await this same promise instead of racing to refresh.
   private refreshAccessToken(): Promise<void> {
-    if (!this.refreshPromise) {
-      this.refreshPromise = this.performRefresh().finally(() => {
-        this.refreshPromise = null;
-      });
-    }
-    return this.refreshPromise;
+    const key = this.refreshLockKey();
+    const inFlight = HttpClient.refreshPromises.get(key);
+    if (inFlight) return inFlight;
+
+    const promise = this.performRefresh().finally(() => {
+      HttpClient.refreshPromises.delete(key);
+    });
+    HttpClient.refreshPromises.set(key, promise);
+    return promise;
   }
 
   private async performRefresh(): Promise<void> {

--- a/packages/compose-react/src/lib/index.ts
+++ b/packages/compose-react/src/lib/index.ts
@@ -5,3 +5,4 @@ export * from "./utils";
 export * from "./cookie-storage";
 export * from "./motion-presets";
 export * from "./theme";
+export * from "./tenant-ownership";

--- a/packages/compose-react/src/lib/tenant-ownership.ts
+++ b/packages/compose-react/src/lib/tenant-ownership.ts
@@ -1,0 +1,141 @@
+/**
+ * Cross-tab ownership of the impersonation cookie.
+ *
+ * The access token lives in a cookie named after the application domain alone -- no tenant, no
+ * project, no per-tab discriminator -- so every tab on the origin shares exactly one token. The tab
+ * that impersonated most recently owns it; every other tab is pointed somewhere it does not know
+ * about.
+ *
+ * Nothing in the browser can detect that from inside a tab. The cookie is `HttpOnly`, so neither
+ * `document.cookie` nor CookieStore change events can see it, and the only server-side signal --
+ * the impersonation status endpoint -- is refetched on window focus. A tab that is *visible but not
+ * focused* (a second monitor) therefore keeps polling happily under another project's token, with
+ * its own store and its own route agreeing with each other and both being stale.
+ *
+ * Comparing two client-side values cannot catch that: the staleness is in both of them. The signal
+ * has to come from outside the tab. This module is that signal.
+ *
+ * `BroadcastChannel` is scoped to the origin, which is precisely the set of tabs that share the
+ * cookie -- coordination reach and conflict reach are the same set, so nothing is over- or
+ * under-notified. Where it is unavailable we fall back to a `localStorage` write, whose `storage`
+ * event fires in every *other* tab of the origin and gives the same reach.
+ */
+
+const CHANNEL_NAME = "blocks:tenant";
+const STORAGE_KEY = "blocks:tenant-owner";
+
+export interface TenantClaim {
+  /** The tenant the claiming tab impersonated. */
+  tenantId: string;
+  /** Identifies the claiming tab so it can ignore its own message. */
+  tabId: string;
+  ts: number;
+}
+
+/** Stable for the lifetime of this document, which is exactly the lifetime of the cookie's owner. */
+export const TAB_ID: string = (() => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+})();
+
+const isBrowser = () => typeof window !== "undefined";
+
+const hasBroadcastChannel = () =>
+  isBrowser() && typeof BroadcastChannel !== "undefined";
+
+let channel: BroadcastChannel | null = null;
+
+const getChannel = (): BroadcastChannel | null => {
+  if (!hasBroadcastChannel()) return null;
+  if (!channel) channel = new BroadcastChannel(CHANNEL_NAME);
+  return channel;
+};
+
+const isTenantClaim = (value: unknown): value is TenantClaim =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as TenantClaim).tenantId === "string" &&
+  typeof (value as TenantClaim).tabId === "string";
+
+/**
+ * Announce that this tab has taken the cookie for `tenantId`.
+ *
+ * Called after a *successful* impersonation only. Announcing an attempt would detach other tabs on
+ * the strength of a call that may still fail, leaving every tab detached and none of them owning
+ * anything.
+ */
+export const claimTenant = (tenantId: string): void => {
+  if (!isBrowser() || !tenantId) return;
+
+  const claim: TenantClaim = { tenantId, tabId: TAB_ID, ts: Date.now() };
+
+  // Written whether or not BroadcastChannel exists: this is also how a newly opened tab discovers
+  // the current owner before it issues its first request (see `readCurrentOwner`).
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(claim));
+  } catch {
+    // Private mode or a storage quota error. The channel below still reaches live tabs; only
+    // cold-start discovery is lost, and the guard treats an unknown owner as "not detached".
+  }
+
+  getChannel()?.postMessage(claim);
+};
+
+/**
+ * The last claim made by any tab on this origin, or null if none is recorded.
+ *
+ * Used on mount so a tab opened while another already owns the cookie starts in the correct state
+ * rather than waiting for the next claim that may never come.
+ */
+export const readCurrentOwner = (): TenantClaim | null => {
+  if (!isBrowser()) return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isTenantClaim(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Subscribe to claims made by other tabs. Returns an unsubscribe function.
+ *
+ * This tab's own claims are filtered out, so a handler only ever sees a tenant change it did not
+ * cause.
+ */
+export const subscribeToTenantClaims = (
+  onClaim: (claim: TenantClaim) => void,
+): (() => void) => {
+  if (!isBrowser()) return () => undefined;
+
+  const handleClaim = (claim: unknown) => {
+    if (!isTenantClaim(claim)) return;
+    if (claim.tabId === TAB_ID) return;
+    onClaim(claim);
+  };
+
+  const bc = getChannel();
+  if (bc) {
+    const listener = (event: MessageEvent) => handleClaim(event.data);
+    bc.addEventListener("message", listener);
+    return () => bc.removeEventListener("message", listener);
+  }
+
+  // Fallback: `storage` fires only in the tabs that did not write, which is the filtering we want
+  // anyway. The tabId check stays as a second line of defence.
+  const listener = (event: StorageEvent) => {
+    if (event.key !== STORAGE_KEY || !event.newValue) return;
+    try {
+      handleClaim(JSON.parse(event.newValue));
+    } catch {
+      // A malformed entry tells us nothing; leaving the tab attached is the safe default because
+      // the route guard still compares the tenant on every render.
+    }
+  };
+  window.addEventListener("storage", listener);
+  return () => window.removeEventListener("storage", listener);
+};

--- a/packages/compose-react/src/store/impersonate.store.ts
+++ b/packages/compose-react/src/store/impersonate.store.ts
@@ -5,6 +5,18 @@ interface ImpersonateStoreState {
   impersonatedTenantId: string | null;
   originalTenantId: string | null;
   isInitialized: boolean;
+  /**
+   * A re-impersonation that failed. Kept in the store rather than swallowed so the guard can render
+   * a terminal state with a way out: a failure used to leave the store pinned to the *previous*
+   * project's tenant, which froze the guard's effect dependencies and meant it never retried.
+   */
+  impersonationError: unknown;
+  /**
+   * True when another tab has claimed the shared access-token cookie for a different tenant.
+   * A detached tab must issue no requests: its own state is stale, and the cookie underneath it
+   * now belongs to someone else.
+   */
+  isDetached: boolean;
   setImpersonation: (
     isImpersonated: boolean,
     originalTenantId: string | null,
@@ -13,6 +25,8 @@ interface ImpersonateStoreState {
   impersonate: (impersonatedTenantId: string, originalTenantId: string) => void;
   terminate: (originalTenantId: string) => void;
   setInitialized: (isInitialized: boolean) => void;
+  setImpersonationError: (impersonationError: unknown) => void;
+  setDetached: (isDetached: boolean) => void;
   reset: () => void;
 }
 
@@ -21,6 +35,8 @@ export const useImpersonateStore = create<ImpersonateStoreState>()((set) => ({
   impersonatedTenantId: null,
   originalTenantId: null,
   isInitialized: false,
+  impersonationError: null,
+  isDetached: false,
   setImpersonation: (
     isImpersonated: boolean,
     originalTenantId: string | null,
@@ -29,7 +45,15 @@ export const useImpersonateStore = create<ImpersonateStoreState>()((set) => ({
     set({ isImpersonated, impersonatedTenantId, originalTenantId });
   },
   impersonate: (impersonatedTenantId: string, originalTenantId: string) => {
-    set({ isImpersonated: true, impersonatedTenantId, originalTenantId });
+    // A successful impersonation clears both failure states: this tab now owns the cookie and is
+    // pointed at the tenant it believes it is pointed at.
+    set({
+      isImpersonated: true,
+      impersonatedTenantId,
+      originalTenantId,
+      impersonationError: null,
+      isDetached: false,
+    });
   },
   terminate: (originalTenantId: string) => {
     set((state) => ({
@@ -42,12 +66,20 @@ export const useImpersonateStore = create<ImpersonateStoreState>()((set) => ({
   setInitialized: (isInitialized: boolean) => {
     set({ isInitialized });
   },
+  setImpersonationError: (impersonationError: unknown) => {
+    set({ impersonationError });
+  },
+  setDetached: (isDetached: boolean) => {
+    set({ isDetached });
+  },
   reset: () => {
     set({
       isImpersonated: false,
       impersonatedTenantId: null,
       originalTenantId: null,
       isInitialized: false,
+      impersonationError: null,
+      isDetached: false,
     });
   },
 }));

--- a/packages/compose-react/src/store/project.store.ts
+++ b/packages/compose-react/src/store/project.store.ts
@@ -51,6 +51,20 @@ export const useProjectStore = create<ProjectStoreState>()(
         set((state) => ({ ...state, selectedTenantGroup: null }));
       },
     }),
-    { name: "project-storage" },
+    {
+      name: "project-storage",
+      // Only the project LIST is persisted, and deliberately so.
+      //
+      // `persist` writes to localStorage, which is shared by every tab on the origin. The list is
+      // identical for all of them, so sharing it is free -- and its synchronous hydration is what
+      // lets the impersonation guard resolve the route's `itemId` to a tenant on the very first
+      // render, before any request goes out.
+      //
+      // `selectedProject` is the opposite: it is per-tab state. Persisting it meant a reload or a
+      // newly opened tab hydrated whichever project *another* tab happened to select last, so the
+      // heading could name one project while the session belonged to another. It is now derived
+      // from the route, which is the only per-tab source of truth we have.
+      partialize: (state) => ({ projects: state.projects }),
+    },
   ),
 );


### PR DESCRIPTION
A tab could render one project's data under another project's name, with no error anywhere. Three things combined to allow it.

The render gate asked "am I impersonating?" when the question that matters is "am I impersonating the project this URL asked for?". isImpersonated stays true while impersonating the wrong tenant, so children rendered regardless. The guard already computed the comparison to decide whether to repair; it just did not use it to decide whether to render. It now resolves the tenant from the route -- the only per-tab source of truth -- and renders nothing unless that matches the impersonated tenant. An unresolvable route is explicitly a third state: it waits, because "not in my copy of the projects list" is not "wrong tenant" and must not bounce people out of valid deep links.

A failed re-impersonation was swallowed into console.error. Because impersonate() never ran, the store stayed pinned to the previous project's tenant while the route kept pointing at this one, which froze the trigger effect's dependencies -- it never ran again, and the page kept serving another tenant's data indefinitely. The failure is now stored and surfaced with Retry and a way back to the console.

Neither of those can see a cookie taken by a different tab: the token is HttpOnly and the status endpoint is only refetched on window focus, so a tab that is visible but unfocused keeps fetching under another project's token with its own store and route agreeing and both stale. Comparing two client-side values cannot catch that, so tabs now announce a successful impersonation over BroadcastChannel (localStorage storage event as fallback) and a tab that loses the cookie detaches and stops fetching until the user takes it back.

Also here, because they are the same failure surface:

- Persist only the project LIST. selectedProject was in localStorage, shared by every tab, so a reload hydrated whichever project another tab last chose. The list stays persisted -- its synchronous hydration is what lets the guard resolve the route on first render.
- Key the refresh lock by refresh target rather than by client instance. iamClient, logicClient and notificationClient all refresh against IAM with the same cookie and lineage, so one focus event could fire three concurrent rotations; losers got invalid_grant and a forced redirect to /login.